### PR TITLE
add lifetime property support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ steps:
 
 - The service account for which you want to acquire an access token.
 
+### `lifetime` (number)
+
+- The time (in seconds) the OIDC token will be valid for before expiry. Must be a non-negative integer. If the flag is omitted or set to 0, the API will choose a default finite lifetime. (default: 0)
+
 ## Developing
 
 To run testing, shellchecks and plugin linting use use `bk run` with the [Buildkite CLI](https://github.com/buildkite/cli).

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -17,7 +17,7 @@ TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'buildkiteXXXX')
 
 echo "~~~ :buildkite: Requesting OIDC token from Buildkite"
 
-buildkite-agent oidc request-token --audience "$BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_AUDIENCE" > "$TMPDIR"/token.json
+buildkite-agent oidc request-token --audience "$BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_AUDIENCE" --lifetime "${BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_LIFETIME:-0}" > "$TMPDIR"/token.json
 
 echo "~~~ :gcloud: Configuring Google Cloud credentials"
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -11,6 +11,8 @@ configuration:
       type: string
     service-account:
       type: string
+    lifetime:
+      type: number
   required:
     - audience
     - service-account

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -57,7 +57,7 @@ setup() {
     export BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_SERVICE_ACCOUNT="buildkite-example-pipeline@oidc-project.iam.gserviceaccount.com"
 
     stub mktemp "-d : echo $BATS_TEST_TMPDIR"
-    stub buildkite-agent "oidc request-token --audience //iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/buildkite-example-pipeline/providers/buildkite : echo dummy-jwt"
+    stub buildkite-agent "oidc request-token --audience //iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/buildkite-example-pipeline/providers/buildkite --lifetime 0 : echo dummy-jwt"
 
     run "$PWD/hooks/pre-command"
 


### PR DESCRIPTION
Hello 👋 

This PR adds the optional [lifetime](https://buildkite.com/docs/agent/v3/cli-oidc#lifetime) property to the plugin to allow customizing the JWT expiration time.