### PR TITLE
feat: add ability to request optional oidc claims for org and pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,4 +11,6 @@ steps:
   - label: ":shell: Shellcheck"
     plugins:
       - shellcheck#v1.3.0:
-          files: hooks/**
+          files:
+            - hooks/**
+            - lib/**

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The path to the file is populated in `GOOGLE_APPLICATION_CREDENTIALS` for SDKs t
 
 - An installed binary that when specified, will run twice to process the values of `audience` and `service-account` via stdin.  This is intended to be used to render environment variables with an application such as `envsubst`. (default: '')
 
+### `claims` (list(string))
+
+- A list of [claims to add to the requested buildkite oidc token](https://buildkite.com/docs/agent/v3/cli-oidc#claims-optional-claims). The agent currently supports requesting claims for `organization_id` and `pipeline_id`. If requested, these will include the respective buildkite organization and/or pipeline UUID claims in the token. (default: [])
+
 ## Example
 
 Add the following to your `pipeline.yml`:

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -2,6 +2,13 @@
 
 set -euo pipefail
 
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck source=lib/shared.bash
+. "$DIR/../lib/shared.bash"
+
+args=()
+
 if [[ -z "${BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_AUDIENCE:-}" ]]; then
   echo "🚨 Missing 'audience' plugin configuration"
   exit 1
@@ -22,12 +29,21 @@ if [[ -n "${BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_RENDER_COMMAND:-}"
   BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_SERVICE_ACCOUNT="$(echo "${BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_SERVICE_ACCOUNT}" | ${BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_RENDER_COMMAND})"
 fi
 
+# add required arguments
+args+=("--audience" "${BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_AUDIENCE}")
+args+=("--lifetime" "${BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_LIFETIME:-0}")
+
+# Parse the list of optional claims to pass to the token request command
+while read -r line ; do
+  [[ -n "$line" ]] && args+=("--claim" "$line")
+done <<< "$(plugin_read_list CLAIMS)"
+
 # Create a temporary directory with both BSD and GNU mktemp
 TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'buildkiteXXXX')
 
 echo "~~~ :buildkite: Requesting OIDC token from Buildkite"
 
-buildkite-agent oidc request-token --audience "$BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_AUDIENCE" --lifetime "${BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_LIFETIME:-0}" > "$TMPDIR"/token.json
+buildkite-agent oidc request-token ${args[@]} > "$TMPDIR"/token.json
 
 echo "~~~ :gcloud: Configuring Google Cloud credentials"
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -43,7 +43,7 @@ TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'buildkiteXXXX')
 
 echo "~~~ :buildkite: Requesting OIDC token from Buildkite"
 
-buildkite-agent oidc request-token ${args[@]} > "$TMPDIR"/token.json
+buildkite-agent oidc request-token "${args[@]}" > "$TMPDIR"/token.json
 
 echo "~~~ :gcloud: Configuring Google Cloud credentials"
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Reads either a value or a list from plugin config
+function plugin_read_list() {
+  prefix_read_list "BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_$1"
+}
+
+# Reads either a value or a list from the given env prefix
+function prefix_read_list() {
+  local prefix="$1"
+  local parameter="${prefix}_0"
+
+  if [[ -n "${!parameter:-}" ]]; then
+    local i=0
+    local parameter="${prefix}_${i}"
+    while [[ -n "${!parameter:-}" ]]; do
+      echo "${!parameter}"
+      i=$((i+1))
+      parameter="${prefix}_${i}"
+    done
+  elif [[ -n "${!prefix:-}" ]]; then
+    echo "${!prefix}"
+  fi
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -15,6 +15,10 @@ configuration:
       type: number
     render-command:
       type: string
+    claims:
+      type: array
+      items:
+        type: string
   required:
     - audience
     - service-account

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -128,3 +128,103 @@ JSON)
     unstub mktemp
     unstub buildkite-agent
 }
+
+@test "exports credentials with optional claim organization id" {
+    export BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_AUDIENCE="//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/buildkite-example-pipeline/providers/buildkite"
+    export BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_SERVICE_ACCOUNT="buildkite-example-pipeline@oidc-project.iam.gserviceaccount.com"
+    export BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_CLAIMS_0="organization_id"
+
+    stub mktemp "-d : echo $BATS_TEST_TMPDIR"
+    stub buildkite-agent "oidc request-token --audience //iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/buildkite-example-pipeline/providers/buildkite --lifetime 0 --claim organization_id : echo dummy-jwt"
+
+    run "$PWD/hooks/pre-command"
+
+    assert_success
+
+    assert_output --partial "Requesting OIDC token from Buildkite"
+    assert_output --partial "Configuring Google Cloud credentials"
+
+    diff $BATS_TEST_TMPDIR/token.json <(echo dummy-jwt)
+    diff $BATS_TEST_TMPDIR/credentials.json <(cat << JSON
+{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/buildkite-example-pipeline/providers/buildkite",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/buildkite-example-pipeline@oidc-project.iam.gserviceaccount.com:generateAccessToken",
+  "credential_source": {
+    "file": "$BATS_TEST_TMPDIR/token.json"
+  }
+}
+JSON)
+
+    unstub mktemp
+    unstub buildkite-agent
+}
+
+@test "exports credentials with optional claim pipeline id" {
+    export BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_AUDIENCE="//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/buildkite-example-pipeline/providers/buildkite"
+    export BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_SERVICE_ACCOUNT="buildkite-example-pipeline@oidc-project.iam.gserviceaccount.com"
+    export BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_CLAIMS_0="pipeline_id"
+
+    stub mktemp "-d : echo $BATS_TEST_TMPDIR"
+    stub buildkite-agent "oidc request-token --audience //iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/buildkite-example-pipeline/providers/buildkite --lifetime 0 --claim pipeline_id : echo dummy-jwt"
+
+    run "$PWD/hooks/pre-command"
+
+    assert_success
+
+    assert_output --partial "Requesting OIDC token from Buildkite"
+    assert_output --partial "Configuring Google Cloud credentials"
+
+    diff $BATS_TEST_TMPDIR/token.json <(echo dummy-jwt)
+    diff $BATS_TEST_TMPDIR/credentials.json <(cat << JSON
+{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/buildkite-example-pipeline/providers/buildkite",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/buildkite-example-pipeline@oidc-project.iam.gserviceaccount.com:generateAccessToken",
+  "credential_source": {
+    "file": "$BATS_TEST_TMPDIR/token.json"
+  }
+}
+JSON)
+
+    unstub mktemp
+    unstub buildkite-agent
+}
+
+@test "exports credentials with optional claims organization_id and pipeline id" {
+    export BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_AUDIENCE="//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/buildkite-example-pipeline/providers/buildkite"
+    export BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_SERVICE_ACCOUNT="buildkite-example-pipeline@oidc-project.iam.gserviceaccount.com"
+    export BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_CLAIMS_0="organization_id"
+    export BUILDKITE_PLUGIN_GCP_WORKLOAD_IDENTITY_FEDERATION_CLAIMS_1="pipeline_id"
+
+    stub mktemp "-d : echo $BATS_TEST_TMPDIR"
+    stub buildkite-agent "oidc request-token --audience //iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/buildkite-example-pipeline/providers/buildkite --lifetime 0 --claim organization_id --claim pipeline_id : echo dummy-jwt"
+
+    run "$PWD/hooks/pre-command"
+
+    assert_success
+
+    assert_output --partial "Requesting OIDC token from Buildkite"
+    assert_output --partial "Configuring Google Cloud credentials"
+
+    diff $BATS_TEST_TMPDIR/token.json <(echo dummy-jwt)
+    diff $BATS_TEST_TMPDIR/credentials.json <(cat << JSON
+{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/buildkite-example-pipeline/providers/buildkite",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/buildkite-example-pipeline@oidc-project.iam.gserviceaccount.com:generateAccessToken",
+  "credential_source": {
+    "file": "$BATS_TEST_TMPDIR/token.json"
+  }
+}
+JSON)
+
+    unstub mktemp
+    unstub buildkite-agent
+}


### PR DESCRIPTION
Add the ability to request [buildkite agent oidc optional claims](https://buildkite.com/docs/agent/v3/cli-oidc#claims-optional-claims).
Buildkite optional claims currently support requesting the organization
id and/or pipeline id in the token. These values are the organization
and pipeline uuid respectively.

These values are useful in ensuring pipelines retain access to resources
if they are renamed. It can also be used to ensure the correct org is
making requests to assume resources.

Fixes #12
