### PR TITLE
Make pre-exit hook compatible with mac agents

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-if [[ -v BUILDKITE_OIDC_TMPDIR ]]; then
+if [[ -n "${BUILDKITE_OIDC_TMPDIR:-}" ]]; then
   rm -rf "$BUILDKITE_OIDC_TMPDIR"
 
   echo "Removed credentials from $BUILDKITE_OIDC_TMPDIR"


### PR DESCRIPTION
When using this plugin on a Mac agent (this happens to be a buildkite-managed agent) it fails at the pre-exit hook with this error: `line 5: conditional binary operator expected`
![image](https://github.com/user-attachments/assets/e74a647c-9398-4fcf-8eae-a96d14885c85)

This is because the bash version is lower than 4.2, where the `-v` flag was introduced. I've slightly changed the conditional to make it compatible with lower versions of bash.

Test output:
```
$ docker run --rm -ti -v "${PWD}":/plugin buildkite/plugin-tester:latest
Unable to find image 'buildkite/plugin-tester:latest' locally
latest: Pulling from buildkite/plugin-tester
339de151aab4: Pull complete
94a52eec71b5: Pull complete
15ab8d50c870: Pull complete
60f0bec009f3: Pull complete
894804dfedf0: Pull complete
9c43d44d3502: Pull complete
47239e842997: Pull complete
a85c53db0754: Pull complete
07df9ecc7ec1: Pull complete
8d514195de6d: Pull complete
0c2689d56aa1: Pull complete
800f12676416: Pull complete
4f4fb700ef54: Pull complete
fed550987e03: Pull complete
ca04eda16946: Pull complete
f708facfe78e: Pull complete
8584cd94b630: Pull complete
301219253c73: Pull complete
Digest: sha256:91718a438d63422b01886143f929a9eb11cf4ea8cedbdb0b26b0e6a104df4141
Status: Downloaded newer image for buildkite/plugin-tester:latest
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
pre-command.bats
 ✓ fails when mktemp fails
 ✓ fails when audience is missing
 ✓ fails when service account is missing
 ✓ fails when render command has non-existent binary
 ✓ succeeds when mktemp fails once
 ✓ exports credentials
 ✓ exports credentials with render command using envsubst
 ✓ exports credentials with optional claim organization id
 ✓ exports credentials with optional claim pipeline id
 ✓ exports credentials with optional claims organization_id and pipeline id
pre-exit.bats
 ✓ removes tmp directory
 ✓ does nothing if the directory is not set

12 tests, 0 failures
```